### PR TITLE
Added xformers support.

### DIFF
--- a/config/cpu.yaml
+++ b/config/cpu.yaml
@@ -13,6 +13,7 @@ trainer:
   half_encoder: false
   use_ema: false
   use_hivemind: false
+  use_xformers: false
   
 checkpoint:
   monitor: 'train_loss'

--- a/config/distributed.yaml
+++ b/config/distributed.yaml
@@ -13,6 +13,7 @@ trainer:
   half_encoder: true
   use_ema: false
   use_hivemind: true
+  use_xformers: false
 
 checkpoint:
   monitor: 'train_loss'

--- a/config/multi-gpu.yaml
+++ b/config/multi-gpu.yaml
@@ -13,6 +13,7 @@ trainer:
   half_encoder: true
   use_ema: true
   use_hivemind: false
+  use_xformers: false
   
 checkpoint:
   monitor: 'train_loss'

--- a/config/single-precision.yaml
+++ b/config/single-precision.yaml
@@ -13,6 +13,7 @@ trainer:
   half_encoder: false
   use_ema: true
   use_hivemind: false
+  use_xformers: false
   
 checkpoint:
   monitor: 'train_loss'

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -14,6 +14,7 @@ trainer:
   use_ema: false
   half_encoder: true
   use_hivemind: false
+  use_xformers: false
   
 checkpoint:
   monitor: 'train_loss'

--- a/config/tpu.yaml
+++ b/config/tpu.yaml
@@ -14,6 +14,7 @@ trainer:
   use_ema: true
   half_encoder: true
   use_hivemind: false
+  use_xformers: false
 
 checkpoint:
   monitor: 'train_loss'

--- a/lib/model.py
+++ b/lib/model.py
@@ -36,6 +36,9 @@ class StableDiffusionModel(pl.LightningModule):
         
         if self.config.trainer.gradient_checkpointing: 
             self.unet.enable_gradient_checkpointing()
+            
+        if self.config.trainer.use_xformers:
+            self.unet.set_use_memory_efficient_attention_xformers(True)
     
     def training_step(self, batch, batch_idx):
         # Convert images to latent space


### PR DESCRIPTION
It was so simple I couldn't not attempt it.
Note that currently, this does not seem to work on some(?) cards at batch size 1.
This commit for diffusers fixes it, though performance at batch 1 is still worse than without xformers. https://github.com/huggingface/diffusers/commit/33d7e89c42e0fe7b4a277d7a5bae12ba14828dd8
At higher batch sizes it seems to work without issue, though right now bsz is set to 1 in buckets.py without regard to trainer.init_batch_size.
I'd have added that too if I could but I am not that good at programming, and I don't want to mess up this code too much.