### PR TITLE
Many changes

### DIFF
--- a/config/colab.yaml
+++ b/config/colab.yaml
@@ -72,8 +72,8 @@ dataset:
     debug: false
     dropout: 0.7
     methods:
-      adjust_brightness: 1.1
-      adjust_contrast: 1.1
+      adjust_brightness: 0.1
+      adjust_contrast: 0.1
       # rotate_with_crop: 5
 
 optimizer:

--- a/config/cpu.yaml
+++ b/config/cpu.yaml
@@ -64,8 +64,8 @@ dataset:
     debug: false
     dropout: 0.7
     methods:
-      adjust_brightness: 1.1
-      adjust_contrast: 1.1
+      adjust_brightness: 0.1
+      adjust_contrast: 0.1
       # rotate_with_crop: 5
 
 optimizer:

--- a/config/distributed.yaml
+++ b/config/distributed.yaml
@@ -78,8 +78,8 @@ dataset:
     debug: false
     dropout: 0.7
     methods:
-      adjust_brightness: 1.1
-      adjust_contrast: 1.1
+      adjust_brightness: 0.1
+      adjust_contrast: 0.1
       # rotate_with_crop: 5
 
 optimizer:

--- a/config/multi-gpu.yaml
+++ b/config/multi-gpu.yaml
@@ -65,8 +65,8 @@ dataset:
     debug: false
     dropout: 0.7
     methods:
-      adjust_brightness: 1.1
-      adjust_contrast: 1.1
+      adjust_brightness: 0.1
+      adjust_contrast: 0.1
       # rotate_with_crop: 5
 
 optimizer:

--- a/config/single-precision.yaml
+++ b/config/single-precision.yaml
@@ -67,8 +67,8 @@ dataset:
     debug: false
     dropout: 0.7
     methods:
-      adjust_brightness: 1.1
-      adjust_contrast: 1.1
+      adjust_brightness: 0.1
+      adjust_contrast: 0.1
       # rotate_with_crop: 5
 
 optimizer:

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -71,8 +71,8 @@ dataset:
     debug: false
     dropout: 0.7
     methods:
-      adjust_brightness: 1.1
-      adjust_contrast: 1.1
+      adjust_brightness: 0.1
+      adjust_contrast: 0.1
       # rotate_with_crop: 5
 
 optimizer:

--- a/config/tpu.yaml
+++ b/config/tpu.yaml
@@ -61,8 +61,8 @@ dataset:
     debug: false
     dropout: 0.7
     methods:
-      adjust_brightness: 1.1
-      adjust_contrast: 1.1
+      adjust_brightness: 0.1
+      adjust_contrast: 0.1
       # rotate_with_crop: 5
 
 optimizer:

--- a/experiment/lora.yaml
+++ b/experiment/lora.yaml
@@ -77,8 +77,8 @@ dataset:
     debug: false
     dropout: 0.7
     methods:
-      adjust_brightness: 1.1
-      adjust_contrast: 1.1
+      adjust_brightness: 0.1
+      adjust_contrast: 0.1
       # rotate_with_crop: 5
 
 optimizer:

--- a/experiment/textual_inversion.py
+++ b/experiment/textual_inversion.py
@@ -170,7 +170,7 @@ class CustomEmbeddingsCallback(Callback):
         params = params[-sum([p[1] for p in lengths]):].detach().clone().cpu()
         for item in lengths:
             entry, length = item
-            if entry in self.trainable_concepts:
+            if entry in self.trainable_concepts or self.config.train_all:
                 embedding = Embedding(params[:length].clone(), entry, step=step)
                 embedding.save(self.save_path / f"{entry}_s{step}.pt")
                 if self.use_wandb:

--- a/experiment/textual_inversion.yaml
+++ b/experiment/textual_inversion.yaml
@@ -6,6 +6,7 @@ custom_embeddings:
   load_all: false
   train_all: false
   use_wandb: false
+  freeze_unet: false
   trainer:
     save_path: 
     lr: 1e-3

--- a/experiment/textual_inversion.yaml
+++ b/experiment/textual_inversion.yaml
@@ -85,8 +85,8 @@ dataset:
     debug: false
     dropout: 0.7
     methods:
-      adjust_brightness: 1.1
-      adjust_contrast: 1.1
+      adjust_brightness: 0.1
+      adjust_contrast: 0.1
       # rotate_with_crop: 5
 
 optimizer:

--- a/lib/augment.py
+++ b/lib/augment.py
@@ -49,17 +49,21 @@ class AugmentTransforms():
         return image.rotate(ang, expand=False, fillcolor=(255,255,255), resample=3).crop((dx, dy, xl, yl))
 
     def flip(self, image, x):
-        return image.transpose(Image.FLIP_LEFT_RIGHT)
+        if random.random() < x:
+            return image.transpose(Image.FLIP_LEFT_RIGHT)
+        return image
 
     def adjust_contrast(self, image, factor):
         enh_con = ImageEnhance.Contrast(image)
         return enh_con.enhance(factor)
 
     def adjust_brightness(self, image, brightness):
+        brightness = 1 + random.randint(-brightness, brightness)
         enh_bri = ImageEnhance.Brightness(image)
         return enh_bri.enhance(brightness)
 
     def adjust_color(self, image, color):
+        color = 1 + random.randint(-color, color)
         enh_col = ImageEnhance.Color(image)
         return enh_col.enhance(color)
 

--- a/trainer.py
+++ b/trainer.py
@@ -84,8 +84,10 @@ def main(args):
         
     if config.lightning.get("strategy") == None:
         config.lightning.strategy = strategy
-    
-    callbacks.append(ModelCheckpoint(**config.checkpoint))
+
+    if not config.get("custom_embeddings") or not config.custom_embeddings.freeze_unet:
+        callbacks.append(ModelCheckpoint(**config.checkpoint))
+
     trainer = pl.Trainer(
         logger=logger, 
         callbacks=callbacks,

--- a/trainer.py
+++ b/trainer.py
@@ -78,6 +78,12 @@ def main(args):
     if config.get("custom_embeddings") != None and config.custom_embeddings.enabled:
         from experiment.textual_inversion import CustomEmbeddingsCallback
         callbacks.append(CustomEmbeddingsCallback(config.custom_embeddings))
+        if not config.custom_embeddings.train_all and not config.custom_embeddings.concepts.trainable:
+            if strategy == 'ddp':
+                strategy = 'ddp_find_unused_parameters_false'
+        if config.custom_embeddings.freeze_unet:
+            if strategy == 'ddp_find_unused_parameters_false':
+                strategy = 'ddp'
         
     if config.get("sampling") != None and config.sampling.enabled:
         callbacks.append(SampleCallback(config.sampling, logger))

--- a/trainer.py
+++ b/trainer.py
@@ -93,7 +93,13 @@ def main(args):
 
     if not config.get("custom_embeddings") or not config.custom_embeddings.freeze_unet:
         callbacks.append(ModelCheckpoint(**config.checkpoint))
+        enable_checkpointing = True
+    else:
+        enable_checkpointing = False
 
+    if config.lightning.get("enable_checkpointing") == None:
+        config.lightning.strategy = enable_checkpointing
+    
     trainer = pl.Trainer(
         logger=logger, 
         callbacks=callbacks,


### PR DESCRIPTION
This PR does the following:
1. Enable save embs if no trainable is defined but `train_all` is set to `True`.
2. Allow freezing unet for emb vector training only.
3. When no emb vector is trainable, disable grad and optimizer for TE
4. Modify the behavior of data augmentations: brightness & contrast are randomly generated instead of fixed constant, with the arguments sets the maximum delta. Flip's argument sets the probability of flipping now.

Everything should be working, but not yet fully tested.