### PR TITLE
Compute aspect ratios in log-space

### DIFF
--- a/data/bucket.py
+++ b/data/bucket.py
@@ -219,7 +219,7 @@ class AspectRatioDataset(RatioDataset):
 
         # Assign images to buckets
         for idx, img_ratio in enumerate(img_ratios):
-            diff = np.abs(self.bucket_ratios - img_ratio)
+            diff = np.abs(np.log(self.bucket_ratios) - np.log(img_ratio))
             bucket_idx = np.argmin(diff)
             self.bucket_content[bucket_idx].append(idx)
             self.to_ratio[idx] = self.bucket_ratios[bucket_idx]

--- a/scripts/encode_latents_xl.py
+++ b/scripts/encode_latents_xl.py
@@ -134,7 +134,7 @@ class LatentEncodingDataset(Dataset):
 
         # Assign images to buckets
         for idx, img_ratio in enumerate(img_ratios):
-            diff = np.abs(self.bucket_ratios - img_ratio)
+            diff = np.abs(np.log(self.bucket_ratios) - np.log(img_ratio))
             bucket_idx = np.argmin(diff)
             self.bucket_content[bucket_idx].append(idx)
             self.to_ratio[idx] = self.bucket_ratios[bucket_idx]


### PR DESCRIPTION
Updates aspect ratio bucketing to align with NovelAI's implementation. See their GitHub repo and paper (specifically footnote [2]) for reference.

https://github.com/NovelAI/novelai-aspect-ratio-bucketing/commits/main/?since=2024-09-25&until=2024-09-25
https://arxiv.org/abs/2409.15997

> [2] aspect ratios compared in log-space have the desirable property that a 1:1 aspect ratio can be equidistant
from buckets 2:1 and 1:2, each of which fit an equal proportion of its area.