### PR TITLE
Add ZTSNR for internal SDXL sampling.

### DIFF
--- a/modules/sdxl_model.py
+++ b/modules/sdxl_model.py
@@ -257,6 +257,9 @@ class StableDiffusionModel(pl.LightningModule):
         )
         if self.config.advanced.get("v_parameterization", False):
             scheduler_params["prediction_type"] = "v_prediction"
+        
+        if self.config.advanced.get("zero_terminal_snr", False):
+            apply_zero_terminal_snr(self.noise_scheduler)
 
         scheduler_cls = get_class(scheduler_name)
         scheduler = scheduler_cls(**scheduler_params)

--- a/modules/sdxl_model.py
+++ b/modules/sdxl_model.py
@@ -259,10 +259,11 @@ class StableDiffusionModel(pl.LightningModule):
             scheduler_params["prediction_type"] = "v_prediction"
         
         if self.config.advanced.get("zero_terminal_snr", False):
-            apply_zero_terminal_snr(self.noise_scheduler)
+            scheduler_params["rescale_betas_zero_snr"] = True
 
         scheduler_cls = get_class(scheduler_name)
         scheduler = scheduler_cls(**scheduler_params)
+        
         prompts_batch = {
             "target_size_as_tuple": torch.stack([torch.asarray(size)]).cuda(),
             "original_size_as_tuple": torch.stack([torch.asarray(size)]).cuda(),


### PR DESCRIPTION
This PR makes sure that the previews for SDXL are generated using Zero Terminal SNR schedule if it was enabled in the train config.