### PR TITLE
Implement condition dropout for SDXL training.

### DIFF
--- a/modules/train_sdxl.py
+++ b/modules/train_sdxl.py
@@ -110,7 +110,11 @@ class SupervisedFineTune(StableDiffusionModel):
             self.first_stage_model.cpu()
             latents = self._normliaze(batch["pixels"])
 
-        cond = self.encode_batch(batch)
+        cond = self.encode_batch(batch)      
+
+        if self.config.advanced.get("condition_dropout_rate", 0.0) > 0.0:
+            cond = self.dropout_cond(cond)
+
         model_dtype = next(self.model.parameters()).dtype
         cond = {k: v.to(model_dtype) for k, v in cond.items()}
 

--- a/modules/train_sdxl.py
+++ b/modules/train_sdxl.py
@@ -110,9 +110,9 @@ class SupervisedFineTune(StableDiffusionModel):
             self.first_stage_model.cpu()
             latents = self._normliaze(batch["pixels"])
 
-        cond = self.encode_batch(batch)      
+        cond = self.encode_batch(batch)
 
-        if self.config.advanced.get("condition_dropout_rate", 0.0) > 0.0:
+        if advanced.get("condition_dropout_rate", 0.0) > 0.0:
             cond = self.dropout_cond(cond)
 
         model_dtype = next(self.model.parameters()).dtype


### PR DESCRIPTION
This PR allows applying condition dropout by zeroing it out for SDXL training which is used to improve CFG performance of large-scale finetunes.