### PR TITLE
Fix RuntimeError: Input type (double) and bias type (float) mismatch …

### DIFF
--- a/modules/sd_model_diffusers.py
+++ b/modules/sd_model_diffusers.py
@@ -75,7 +75,7 @@ class StableDiffusionModel(pl.LightningModule):
         latents = []
         for i in range(0, feed_pixel_values.shape[0], self.vae_encode_bsz):
             with torch.autocast("cuda", enabled=False):
-                lat = self.vae.encode(feed_pixel_values[i : i + self.vae_encode_bsz]).latent_dist.sample()
+                lat = self.vae.encode(feed_pixel_values.float()[i : i + self.vae_encode_bsz]).latent_dist.sample()
             latents.append(lat)
         latents = torch.cat(latents, dim=0)
         latents = latents * self.vae.config.scaling_factor


### PR DESCRIPTION
## Training Configuration

Model: NAI Anime v2 (2GB safetensors file)
Resolution: 1024x1024 training
Data: Danbooru2023-webp-4Mpixel dataset (extracted from tar files)
Config file: train_sd15.yaml
Precision: Tested with both 16-mixed and 32, both failed
Batch size: 1 (minimal configuration)

## Root Cause Analysis
<img width="1920" height="1019" alt="image" src="https://github.com/user-attachments/assets/1da3e826-0078-4898-89c5-0e0ee9af376c" />

The issue occurs because pixel data is loaded as torch.float64 (double precision) somewhere in the data pipeline, but the VAE model weights are torch.float32 (single precision). This creates a type mismatch when the VAE encoder tries to process the input tensors.
The error consistently happens at line 78 in modules/sd_model_diffusers.py during the VAE encoding step:
pythonlat = self.vae.encode(feed_pixel_values[i : i + self.vae_encode_bsz]).latent_dist.sample()
## Solution
Add .float() conversion to ensure VAE input is always torch.float32 before processing:
Modified line 78 in modules/sd_model_diffusers.py:

#  Before
`lat = self.vae.encode(feed_pixel_values[i : i + self.vae_encode_bsz]).latent_dist.sample()`

#  After  
`lat = self.vae.encode(feed_pixel_values.float()[i : i + self.vae_encode_bsz]).latent_dist.sample()`

## Testing Results

 Training now starts successfully with the same configuration that previously failed


## Environment Details

Python: 3.10
CUDA: Available
Dataset format: WebP images from Danbooru2023 tar archives
Hardware: 48GB GPU memory

##  Impact
This fix resolves a blocking issue that prevented training with certain data loading configurations, particularly when using:

```
High-resolution training (1024x1024)
Danbooru dataset format
NAI anime models
Various precision settings
```

The fix is surgical and only affects the specific error case while maintaining full compatibility with existing working setups.
Files Changed

modules/sd_model_diffusers.py: Add dtype conversion for VAE encoder input (1 line change)